### PR TITLE
[FEAT] Add optional Docker Hub login to avoid rate limits

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -52,6 +52,10 @@ on:
         required: false
       docker_registry_token:
         required: false
+      dockerhub_username:
+        required: false
+      dockerhub_token:
+        required: false
 
 jobs:
   build:
@@ -88,6 +92,13 @@ jobs:
           service_account_key: ${{ secrets.service_account_key }}
           registry: ${{ inputs.registry }}
           docker_registry_token: ${{ secrets.docker_registry_token }}
+
+      - name: Log in to Docker Hub
+        if: ${{ secrets.dockerhub_username != '' && secrets.dockerhub_token != '' }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.dockerhub_username }}
+          password: ${{ secrets.dockerhub_token }}
 
       - name: Extract metadata (tags, labels) Docker image.
         id: meta
@@ -128,6 +139,13 @@ jobs:
     needs:
       - build
     steps:
+      - name: Log in to Docker Hub
+        if: ${{ secrets.dockerhub_username != '' && secrets.dockerhub_token != '' }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.dockerhub_username }}
+          password: ${{ secrets.dockerhub_token }}
+
       - name: Push digests
         uses: FhenixProtocol/actions/.github/actions/push-digests@2.x.x
         with:

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -139,13 +139,6 @@ jobs:
     needs:
       - build
     steps:
-      - name: Log in to Docker Hub
-        if: ${{ secrets.dockerhub_username != '' && secrets.dockerhub_token != '' }}
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.dockerhub_username }}
-          password: ${{ secrets.dockerhub_token }}
-
       - name: Push digests
         uses: FhenixProtocol/actions/.github/actions/push-digests@2.x.x
         with:


### PR DESCRIPTION
## Summary
- Adds `dockerhub_username` and `dockerhub_token` as optional secrets to the reusable `docker_build.yml` workflow
- Adds Docker Hub login step in both `build` job, gated by `if` so repos not passing these secrets are unaffected
- Fixes Docker Hub 429 rate limit errors in CI by authenticating pulls
